### PR TITLE
Add logging to JSON backend workflows

### DIFF
--- a/b_backendjson.py
+++ b/b_backendjson.py
@@ -1,17 +1,52 @@
+import logging
 import os
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import List, Optional
+
+from langchain.output_parsers import OutputFixingParser, PydanticOutputParser
 from langchain.prompts import ChatPromptTemplate, HumanMessagePromptTemplate
-from langchain_community.chat_models import ChatOpenAI
-from typing import Optional
-from langchain.output_parsers import PydanticOutputParser
-from pydantic import BaseModel, Field
-from typing import List
-from langchain.output_parsers import OutputFixingParser
 from langchain.schema import OutputParserException
-from langchain.prompts import ChatPromptTemplate, HumanMessagePromptTemplate
+from langchain_community.chat_models import ChatOpenAI
+from pydantic import BaseModel, Field
 
 import a_env_vars
-import os
+
 os.environ["OPENAI_API_KEY"] = a_env_vars.OPENAI_API_KEY
+
+
+logger = logging.getLogger(__name__)
+
+
+def _configure_logging() -> None:
+    """Configura el sistema de logging del módulo JSON."""
+    if logger.handlers:
+        return
+
+    logger.setLevel(logging.INFO)
+
+    log_dir = Path("logs")
+    log_dir.mkdir(exist_ok=True)
+
+    formatter = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(name)s - %(message)s"
+    )
+
+    file_handler = RotatingFileHandler(
+        log_dir / "backendjson.log",
+        maxBytes=1_048_576,
+        backupCount=5,
+        encoding="utf-8",
+    )
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+
+_configure_logging()
 
 # Define a new Pydantic model with field descriptions and tailored for Twitter.
 class Command(BaseModel):
@@ -57,52 +92,82 @@ chat_model = ChatOpenAI(
     max_tokens=1000
 )
 conversations = {}
+
+
 def consulta(user_id, systemQuestion, input_usuario, company, clearHistory):
-    if (clearHistory=='1'):
-        print("Borrando historico")
-        conversations[user_id] = []
-    else:
-        print("Mantener historico")
-     
-    conversation_history = conversations.get(user_id, [])
+    logger.info(
+        "Procesando consulta JSON para user_id=%s, company=%s, reiniciar_historial=%s",
+        user_id,
+        company,
+        clearHistory,
+    )
 
-    # Generar una respuesta utilizando ChatGPT
-    if (conversation_history==[]):
-        input_text = ' '.join([input_usuario]) 
-    else:
-        input_text = 'Historial conversación: '.join(conversation_history +   ['| Nueva pregunta:'+input_usuario])
+    try:
+        if clearHistory == '1':
+            logger.info("Reinicio de historial solicitado para user_id=%s", user_id)
+            conversations[user_id] = []
+        else:
+            logger.debug("Se mantiene el historial existente para user_id=%s", user_id)
 
-    _input = prompt.format_prompt(question=input_text, system_question=systemQuestion)
-    output = chat_model(_input.to_messages())
-    
-    conversation_history.append(input_usuario)
-   
-    conversations[user_id] = conversation_history
+        conversation_history = conversations.get(user_id, [])
+        logger.debug(
+            "Historial actual para user_id=%s: %s",
+            user_id,
+            conversation_history,
+        )
 
-    return (output.content)
+        if not conversation_history:
+            input_text = ' '.join([input_usuario])
+        else:
+            input_text = 'Historial conversación: '.join(
+                conversation_history + ['| Nueva pregunta:' + input_usuario]
+            )
+
+        logger.debug("Entrada construida para user_id=%s: %s", user_id, input_text)
+
+        _input = prompt.format_prompt(
+            question=input_text,
+            system_question=systemQuestion,
+        )
+        logger.debug("Prompt generado para user_id=%s", user_id)
+
+        output = chat_model(_input.to_messages())
+        logger.info("Respuesta generada correctamente para user_id=%s", user_id)
+
+        conversation_history.append(input_usuario)
+        conversations[user_id] = conversation_history
+
+        return output.content
+    except Exception:
+        logger.exception(
+            "Error al procesar la consulta JSON para user_id=%s",
+            user_id,
+        )
+        raise
 
         
     try:
         parsed = parser.parse(output.content)
-    except OutputParserException as e:
+    except OutputParserException:
         new_parser = OutputFixingParser.from_llm(
             parser=parser,
             llm=ChatOpenAI()
         )
         parsed = new_parser.parse(output.content)
-    print(parsed)
+    logger.debug("Resultado parseado para user_id=%s: %s", user_id, parsed)
     return parsed
+
 
 def singleConsulta(user_id, systemQuestion, input_usuario, clearHistory):
     """Generar una respuesta utilizando ChatGPT con manejo de historial."""
-    
+
     # Manejo del historial según el parámetro clearHistory
     if clearHistory == '1':
-        print("Borrando histórico de conversación.")
+        logger.info("Reinicio de historial solicitado para user_id=%s", user_id)
         conversations[user_id] = []
     else:
-        print("Manteniendo histórico de conversación.")
-    
+        logger.debug("Manteniendo historial existente para user_id=%s", user_id)
+
     # Obtener el historial de conversación actual
   #  conversation_history = conversations.get(user_id, [])
 
@@ -124,11 +189,15 @@ def singleConsulta(user_id, systemQuestion, input_usuario, clearHistory):
     # Generar la respuesta del modelo
     try:
         output = chat_model(_input.to_messages())
-    except OutputParserException as e:
-        print(f"Error al procesar la respuesta: {e}")
+        logger.info("Respuesta de singleConsulta generada para user_id=%s", user_id)
+    except OutputParserException:
+        logger.exception(
+            "Error al procesar la respuesta del modelo para user_id=%s",
+            user_id,
+        )
         return {"error": "Error al generar la respuesta del modelo."}
-    except Exception as e:
-        print(f"Error inesperado: {e}")
+    except Exception:
+        logger.exception("Error inesperado en singleConsulta para user_id=%s", user_id)
         return {"error": "Ha ocurrido un error inesperado."}
 
     # Actualizar el historial de conversación


### PR DESCRIPTION
## Summary
- add rotating file and console logging setup for the JSON backend module
- replace standard output messages with structured logging across consulta flows
- log success and error paths when generating ChatGPT responses

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ff8eea980083298f0e03af564d8779